### PR TITLE
Change exec to child_process.spawn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mediainfo-parser",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Javascript MediaInfo parser",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -37,9 +37,10 @@ export default function parse(buffer, callback = () => {}) {
 }
 
 function exec(mediaPath, callback = () => {}) {
-  childProcess.exec(`mediainfo --Full --Output=XML "${mediaPath}"`, (stderr, stdout) => {
-    parse(stdout, callback);
-  });
+  const mediainfo = childProcess.spawn('mediainfo', ['--Full', '--Output=XML', mediaPath]);
+  let output = '';
+  mediainfo.stdout.on('data', (data) => { output += data.toString('utf8'); });
+  mediainfo.on('close', () => parse(output, callback));
 }
 
 export {parse, exec};


### PR DESCRIPTION
It can now handle bigger XML input.
Overflow may happen with base64 album cover in audio files